### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,36 @@
 
 # eOSdock-themeswitcher
 
-To use with eOS new dock
+To use with eOS new dock<br>
 I am still working on cool themes:
 
-Stellas Special: My own take. Close to default
-Plank-Classic: the old Plank look
-Princess Eyebleed : Something horribly pastel
-Aqua : Something more MacOS-y
+- Stellas Special: My own take. Close to default
+- Plank-Classic: the old Plank look
+- Princess Eyebleed : Something horribly pastel
+- Aqua : Something more MacOS-y
 
-THE SCRIPT WORKS; BUT EVERYTHING IN THIS REPO IS BRAND NEW AND THERES VERY LITTLE YET
+THE SCRIPT WORKS; BUT EVERYTHING IN THIS REPO IS BRAND NEW AND THERES VERY LITTLE YET<br>
 Not even really example scripts
 
 
 ### Usage:
 
 To set theme.css as the current dock theme
-<table><tr><td>$ eOSdock-themeswitcher.sh ./themes/theme.css</td></tr></table>
-
+```bash
+$ eOSdock-themeswitcher.sh ./themes/theme.css
+```
 
 No argument, to revert to default
-<table><tr><td>$ eOSdock-themeswitcher.sh</td></tr></table>
-
+```bash
+$ eOSdock-themeswitcher.sh</td></tr></table>
+```
 
 login-logout for change to take effect, or do
-<table><tr><td>$ killall io.elementary.dock</td></tr></table>
+```bash
+$ killall io.elementary.dock</td></tr></table>
+```
 
-
-The file doesnt overwrite gtk.css, and reverts to default without leaving anything else.
+The file doesnt overwrite gtk.css, and reverts to default without leaving anything else.<br>
 This is per user, and does not require sudo
 
 i would do the killall in the script if somehow that didnt crash my session everytime i tried


### PR DESCRIPTION
Description from the commit message:
```
This does some changes to the README to make it get rendered correctly, with linebreaks and lists.
- Add explicit line-breaks (<br>) where necessary to reflect the raw markdown
- turn l7-10 into a proper bulleted list
- switch out table-based codeblocks with proper codeblocks
```

Also, I synced with upstream right before this PR, so there is one dangling merge commit that can be ignored.