### PR TITLE
Set 'strict mode' for the script

### DIFF
--- a/eOSdock-themeswitcher.sh
+++ b/eOSdock-themeswitcher.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 # Manage dock themes
 
 #========================


### PR DESCRIPTION
Good explanation is here:
http://redsymbol.net/articles/unofficial-bash-strict-mode/

TL;DR: It sets options for the bash script to avoid common mistakes and errors to make debugging easier.